### PR TITLE
Fixes on mysqlsh execs for MDS

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 data "oci_core_images" "images_for_shape" {
-    compartment_id = "${var.compartment_ocid}"
+    compartment_id = var.compartment_ocid
     operating_system = "Oracle Linux"
     operating_system_version = "8"
     shape = "${var.node_shape}"
@@ -12,8 +12,8 @@ data "oci_identity_availability_domains" "ad" {
 }
 
 data "template_file" "ad_names" {
-  count    = "${length(data.oci_identity_availability_domains.ad.availability_domains)}"
-  template = "${lookup(data.oci_identity_availability_domains.ad.availability_domains[count.index], "name")}"
+  count    = length(data.oci_identity_availability_domains.ad.availability_domains)
+  template = lookup(data.oci_identity_availability_domains.ad.availability_domains[count.index], "name")
 }
 
 
@@ -178,14 +178,14 @@ resource "oci_core_subnet" "private" {
 }
 
 module "mds-instance" {
-    source         = "./modules/mds-instance"
-    admin_password = var.admin_password
-    admin_username = var.admin_username
-    availability_domain = "${data.template_file.ad_names.*.rendered[0]}"
-    configuration_id = data.oci_mysql_mysql_configurations.shape.configurations[0].id
-    compartment_ocid = var.compartment_ocid
-    subnet_id = "${oci_core_subnet.private.id}"
-    display_name = "MySQLInstance"
+  source         = "./modules/mds-instance"
+  admin_password = var.admin_password
+  admin_username = var.admin_username
+  availability_domain = "${data.template_file.ad_names.*.rendered[0]}"
+  configuration_id = data.oci_mysql_mysql_configurations.shape.configurations[0].id
+  compartment_ocid = var.compartment_ocid
+  subnet_id = "${oci_core_subnet.private.id}"
+  display_name = "MySQLInstance"
 }
 
 module "wordpress" {
@@ -196,8 +196,10 @@ module "wordpress" {
   shape                 = "${var.node_shape}"
   label_prefix          = "${var.label_prefix}"
   subnet_id             = "${oci_core_subnet.public.id}"
-  ssh_authorized_keys   = var.ssh_authorized_keys_path == "" ? tls_private_key.public_private_key_pair.public_key_openssh : file("${var.ssh_authorized_keys_path}")
-  ssh_private_key       = var.ssh_private_key_path == "" ? tls_private_key.public_private_key_pair.private_key_pem : file("${var.ssh_private_key_path}")
+  #ssh_authorized_keys   = var.ssh_authorized_keys_path == "" ? tls_private_key.public_private_key_pair.public_key_openssh : file("${var.ssh_authorized_keys_path}")
+  #ssh_private_key       = var.ssh_private_key_path == "" ? tls_private_key.public_private_key_pair.private_key_pem : file("${var.ssh_private_key_path}")
+  ssh_authorized_keys   = tls_private_key.public_private_key_pair.public_key_openssh 
+  ssh_private_key       = tls_private_key.public_private_key_pair.private_key_pem
   mds_ip                = "${module.mds-instance.private_ip}"
   admin_password        = var.admin_password
   admin_username        = var.admin_username

--- a/modules/mds-instance/main.tf
+++ b/modules/mds-instance/main.tf
@@ -1,7 +1,4 @@
-
-
 resource "oci_mysql_mysql_db_system" "MDSinstance" {
-    #Required
     admin_password = var.admin_password
     admin_username = var.admin_username
     availability_domain = var.availability_domain
@@ -10,7 +7,5 @@ resource "oci_mysql_mysql_db_system" "MDSinstance" {
     shape_name = var.mysql_shape
     subnet_id = var.subnet_id
     data_storage_size_in_gb = var.mysql_data_storage_in_gb
-
     display_name = var.display_name
-
 }

--- a/modules/wordpress/scripts/create_wp_db.sh
+++ b/modules/wordpress/scripts/create_wp_db.sh
@@ -1,8 +1,11 @@
 #!/bin/bash 
 
+#mysqlsh ${admin_username}:'${admin_password}'@${mds_ip} --sql -e "CREATE DATABASE ${wp_schema};"
+#mysqlsh ${admin_username}:'${admin_password}'@${mds_ip} --sql -e "CREATE USER ${wp_name} identified by '${wp_password}';"
+#mysqlsh ${admin_username}:'${admin_password}'@${mds_ip} --sql -e "GRANT ALL PRIVILEGES ON ${wp_schema}.* TO ${wp_name};"
 
-mysqlsh ${admin_username}:'${admin_password}'@${mds_ip} --sql -e "CREATE DATABASE ${wp_schema};"
-mysqlsh ${admin_username}:'${admin_password}'@${mds_ip} --sql -e "CREATE USER ${wp_name} identified by '${wp_password}';"
-mysqlsh ${admin_username}:'${admin_password}'@${mds_ip} --sql -e "GRANT ALL PRIVILEGES ON ${wp_schema}.* TO ${wp_name};"
+mysqlsh --user ${admin_username} --password=${admin_password} --host ${mds_ip} --sql -e "CREATE DATABASE ${wp_schema};"
+mysqlsh --user ${admin_username} --password=${admin_password} --host ${mds_ip} --sql -e "CREATE USER ${wp_name} identified by '${wp_password}';"
+mysqlsh --user ${admin_username} --password=${admin_password} --host ${mds_ip} --sql -e "GRANT ALL PRIVILEGES ON ${wp_schema}.* TO ${wp_name};"
 
 echo "WordPress Database and User created !"

--- a/output.tf
+++ b/output.tf
@@ -13,3 +13,7 @@ output "wordpress_db_password" {
 output "mds_instance_ip" {
   value = "${module.mds-instance.private_ip}"
 }
+
+output "generated_ssh_private_key" {
+  value = tls_private_key.public_private_key_pair.private_key_pem
+}


### PR DESCRIPTION
I have fixed the script to create the wp_schema database. The previous syntax was not working (old commands have been commented out):

```
#!/bin/bash 

#mysqlsh ${admin_username}:'${admin_password}'@${mds_ip} --sql -e "CREATE DATABASE ${wp_schema};"
#mysqlsh ${admin_username}:'${admin_password}'@${mds_ip} --sql -e "CREATE USER ${wp_name} identified by '${wp_password}';"
#mysqlsh ${admin_username}:'${admin_password}'@${mds_ip} --sql -e "GRANT ALL PRIVILEGES ON ${wp_schema}.* TO ${wp_name};"

mysqlsh --user ${admin_username} --password=${admin_password} --host ${mds_ip} --sql -e "CREATE DATABASE ${wp_schema};"
mysqlsh --user ${admin_username} --password=${admin_password} --host ${mds_ip} --sql -e "CREATE USER ${wp_name} identified by '${wp_password}';"
mysqlsh --user ${admin_username} --password=${admin_password} --host ${mds_ip} --sql -e "GRANT ALL PRIVILEGES ON ${wp_schema}.* TO ${wp_name};"

```
Please merge it with this repo main branch. 

Additionally, I have removed the customer ssh key pair as it is more secure to generate it with TLS only (especially important for ORM) 